### PR TITLE
gnutar - Added some support for OLD GNU tar syntax found in the wild

### DIFF
--- a/gnutar.grammar
+++ b/gnutar.grammar
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ufwb version="1.14">
-    <grammar name="TAR" start="id:1" author="Johannes Schriewer" email="hallo@dunkelstern.de" fileextension="tar" uti="public.tar-archive" complete="yes">
+<ufwb version="1.17">
+    <grammar name="TAR" start="id:3" author="Johannes Schriewer" email="hallo@dunkelstern.de" fileextension="tar" uti="public.tar-archive" complete="yes">
         <description>Grammar for TAR files</description>
         <scripts>
             <script name="Octal in ASCII representation" type="DataType" id="98">
@@ -69,24 +69,25 @@ def fillByteRange(value, byteArray, bitPos, bitLength):
 </source>
             </script>
         </scripts>
-        <structure name="File" id="142" encoding="ISO_8859-1:1987" endian="big" signed="no">
-            <string name="Filename" id="2" fillcolor="FFD478" type="fixed-length" length="100"/>
-            <structure name="Mode" id="3" length="8">
-                <string name="Octal_designator" mustmatch="yes" id="4" type="fixed-length" length="2">
+        <structure name="File" id="4" encoding="ISO_8859-1:1987" endian="big" signed="no">
+            <string name="Filename" id="5" fillcolor="FFD478" type="fixed-length" length="100"/>
+            <structure name="Mode" id="6" length="8">
+                <string name="Octal_designator" mustmatch="yes" id="7" type="fixed-length" length="2">
                     <fixedvalues>
                         <fixedvalue name="padding" value="00"/>
+                        <fixedvalue name="unknown" value="01"/>
                     </fixedvalues>
                 </string>
-                <string name="Set_On_Execute" id="5" fillcolor="FF9300" type="fixed-length" length="1">
+                <string name="Set_On_Execute" id="8" fillcolor="FF9300" type="fixed-length" length="2">
                     <fixedvalues>
-                        <fixedvalue name="Set UID" value="4"/>
-                        <fixedvalue name="Set GID" value="2"/>
-                        <fixedvalue name="Set UID and GID" value="6"/>
-                        <fixedvalue name="Reserved" value="1"/>
-                        <fixedvalue name="None" value="0"/>
+                        <fixedvalue name="Set UID" value="40"/>
+                        <fixedvalue name="Set GID" value="20"/>
+                        <fixedvalue name="Set UID and GID" value="60"/>
+                        <fixedvalue name="Reserved" value="01"/>
+                        <fixedvalue name="None" value="00"/>
                     </fixedvalues>
                 </string>
-                <string name="Access_Rights" mustmatch="yes" id="6" fillcolor="FF9300" repeatmin="3" repeatmax="3" type="fixed-length" length="1">
+                <string name="Access_Rights" mustmatch="yes" id="9" fillcolor="FF9300" repeatmin="3" repeatmax="3" type="fixed-length" length="1">
                     <fixedvalues>
                         <fixedvalue name="No Rights" value="0"/>
                         <fixedvalue name="X" value="1"/>
@@ -99,12 +100,12 @@ def fillByteRange(value, byteArray, bitPos, bitLength):
                     </fixedvalues>
                 </string>
             </structure>
-            <custom name="UID" id="8" fillcolor="73FDFF" length="8" script="id:98"/>
-            <custom name="GID" id="9" fillcolor="75D5FF" length="8" script="id:98"/>
-            <custom name="FileSize" id="10" fillcolor="D783FF" length="12" script="id:98"/>
-            <custom name="ModificationTime" id="11" length="12" script="id:98"/>
-            <custom name="Checksum" id="12" length="8" script="id:98"/>
-            <string name="Type" id="13" type="fixed-length" length="1">
+            <custom name="UID" id="11" fillcolor="73FDFF" length="8" script="id:98"/>
+            <custom name="GID" id="12" fillcolor="75D5FF" length="8" script="id:98"/>
+            <custom name="FileSize" id="13" fillcolor="D783FF" length="12" script="id:98"/>
+            <custom name="ModificationTime" id="14" length="12" script="id:98"/>
+            <custom name="Checksum" id="15" length="8" script="id:98"/>
+            <string name="Type" id="16" type="fixed-length" length="1">
                 <fixedvalues>
                     <fixedvalue name="File" value="0"/>
                     <fixedvalue name="File" value="\0"/>
@@ -117,30 +118,27 @@ def fillByteRange(value, byteArray, bitPos, bitLength):
                     <fixedvalue name="Reserved" value="7"/>
                     <fixedvalue name="Extended Header" value="x"/>
                     <fixedvalue name="Global Extended Header" value="g"/>
+                    <fixedvalue name="Long Link" value="L"/>
                 </fixedvalues>
             </string>
-            <string name="Linkname" id="14" type="fixed-length" length="100"/>
-            <string name="Magic" mustmatch="yes" id="15" type="zero-terminated">
+            <string name="Linkname" id="17" type="fixed-length" length="100"/>
+            <binary name="Magic" mustmatch="yes" id="18" length="8">
                 <fixedvalues>
-                    <fixedvalue name="Magic" value="ustar"/>
+                    <fixedvalue name="Gnu Old" value="7573746172202000"/>
+                    <fixedvalue name="POSIX" value="7573746172003030"/>
                 </fixedvalues>
-            </string>
-            <string name="Version" mustmatch="yes" id="16" type="fixed-length" length="2">
-                <fixedvalues>
-                    <fixedvalue name="Zero" value="00"/>
-                </fixedvalues>
-            </string>
-            <string name="Username" id="17" fillcolor="73FDFF" type="fixed-length" length="32"/>
-            <string name="Groupname" id="18" fillcolor="75D5FF" type="fixed-length" length="32"/>
-            <custom name="Dev_Major" id="19" length="8" script="id:98"/>
-            <custom name="Dev_Minor" id="20" length="8" script="id:98"/>
-            <binary name="Prefix" id="134" strokecolor="FEFFFF" fillcolor="EAEAEA" length="155"/>
-            <binary name="HeaderPadding" id="135" strokecolor="FEFFFF" length="12"/>
-            <binary name="FileData" id="136" strokecolor="941100" fillcolor="FFE3E3" length="FileSize"/>
-            <binary name="FilePadding" id="137" strokecolor="FEFFFF" fillcolor="EAEAEA" length="select(mod(FileSize, 512) - 1, 0, 512 - mod(FileSize, 512), 512 - mod(FileSize, 512))"/>
+            </binary>
+            <string name="Username" id="19" fillcolor="73FDFF" type="fixed-length" length="32"/>
+            <string name="Groupname" id="20" fillcolor="75D5FF" type="fixed-length" length="32"/>
+            <custom name="Dev_Major" id="21" length="8" script="id:98"/>
+            <custom name="Dev_Minor" id="22" length="8" script="id:98"/>
+            <binary name="Prefix" id="23" strokecolor="FEFFFF" fillcolor="EAEAEA" length="155"/>
+            <binary name="HeaderPadding" id="24" strokecolor="FEFFFF" length="12"/>
+            <binary name="FileData" id="25" strokecolor="941100" fillcolor="FFE3E3" length="FileSize"/>
+            <binary name="FilePadding" id="26" strokecolor="FEFFFF" fillcolor="EAEAEA" length="select(mod(FileSize, 512) - 1, 0, 512 - mod(FileSize, 512), 512 - mod(FileSize, 512))"/>
         </structure>
-        <structure name="TAR_File" id="1" length="0" encoding="UTF-8" endian="dynamic" signed="no">
-            <structref name="File" id="144" repeatmax="-1" structure="id:142"/>
+        <structure name="TAR_File" id="3" length="0" encoding="UTF-8" endian="dynamic" signed="no">
+            <structref name="File" id="28" repeatmax="-1" structure="id:4"/>
         </structure>
     </grammar>
 </ufwb>


### PR DESCRIPTION
I'm not sure if I should have created a variable (structure-based) match for the file modes. As a precaution, I kept `mustmatch` to false for `Set_On_Execute`.